### PR TITLE
Fix Windows release builds with Zig master

### DIFF
--- a/mbedtls.zig
+++ b/mbedtls.zig
@@ -35,7 +35,7 @@ pub fn create(b: *Builder, target: std.zig.CrossTarget, optimize: std.builtin.Op
     ret.linkLibC();
 
     if (target.isWindows())
-        ret.linkSystemLibrary("ws2_32");
+        ret.linkSystemLibraryName("ws2_32");
 
     return Library{ .step = ret };
 }


### PR DESCRIPTION
On Windows, `linkSystemLibrary()` leads to Zig master wanting to invoke `pkg-config` via `linkSystemLibraryInner()` setting `.use_pkg_config = .yes`.

Since `pkg-config` isn't a Windows thing, the build breaks for release builds such as ReleaseFast.

IMHO, using `linkSystemLibraryName()` is the saner option anyway, as it's provided by Zig.

Note: when building within a Cygwin (and probably also applicable to a WSL2 shell) that provides a `pkg-config` executable, this isn't an issue for obvious reasons.